### PR TITLE
uprev and switch to .deb package as source

### DIFF
--- a/google-chrome/actions.py
+++ b/google-chrome/actions.py
@@ -11,9 +11,11 @@ from pisi.actionsapi import shelltools
 WorkDir = "."
 NoStrip = ["/"]
 
+Release = "-1"
+
 def setup():
-    shelltools.system("rpm2targz -v %s/google-chrome-stable_current_x86_64.rpm" %get.workDIR())
-    shelltools.system("tar xfvz %s/google-chrome-stable_current_x86_64.tar.gz --exclude=usr/share/gnome-control-center --exclude=usr/bin --exclude=etc" %get.workDIR())
+    shelltools.system("ar xf %s/google-chrome-stable_%s%s_amd64.deb" % (get.workDIR(), get.srcVERSION(), Release))
+    shelltools.system("tar xvf %s/data.tar.xz --exclude=usr/share/gnome-control-center --exclude=usr/bin --exclude=etc" %get.workDIR())
     shelltools.chmod(get.workDIR() + "/opt/google/chrome/*", 0755)
 
 def install():

--- a/google-chrome/pspec.xml
+++ b/google-chrome/pspec.xml
@@ -14,9 +14,10 @@
         <IsA>app:gui</IsA>
         <Summary>Google Chrome for Linux</Summary>
         <Description>Google Chrome is another web browser which runs web pages and applications with lightning speed due to its superior JavaScript rendering engine.</Description>
-        <Archive sha1sum="8dcee461a9f32a0e02fba1c1aec827d476f84b1a" type="binary">https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm</Archive>
-	<BuildDependencies>
+        <Archive sha1sum="dc435f866d61930d5db71588b289e1ead1016ec6" type="binary">http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_54.0.2840.71-1_amd64.deb</Archive>
+        <BuildDependencies>
             <Dependency>rpm2targz</Dependency>
+            <Dependency>binutils</Dependency>
         </BuildDependencies>
     </Source>
     <Package>
@@ -70,9 +71,17 @@
             <Path fileType="data">/opt/google/</Path>
             <Path fileType="data">/usr/share/pixmaps/</Path>
             <Path fileType="data">/usr/share/applications/</Path>
+            <Path fileType="data">/usr/share/menu/</Path>
         </Files>
     </Package>
     <History>
+        <Update release="12">
+            <Date>10-27-2016</Date>
+            <Version>54.0.2840.71</Version>
+            <Comment>Update to 54.0.2840.71</Comment>
+            <Name>Aaron Johnson</Name>
+            <Email>acjohnson@pcdomain.com</Email>
+        </Update>
         <Update release="11">
             <Date>2016-08-04</Date>
             <Version>52.0.2743.116</Version>


### PR DESCRIPTION
Uses the deb google-chrome-stable package that has explicit versioning in the filename:
```shell
http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_54.0.2840.71-1_amd64.deb
```
This makes the package build process more reliable and consistent.